### PR TITLE
RA-737 wrap call to providerService.getProvidersByPerson by granting the "view providers" privilege and then removing it once it is not needed.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appui/UiSessionContext.java
+++ b/omod/src/main/java/org/openmrs/module/appui/UiSessionContext.java
@@ -14,6 +14,7 @@ import org.openmrs.module.appframework.context.SessionContext;
 import org.openmrs.module.appui.simplifier.UserSimplifier;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
+import org.openmrs.util.PrivilegeConstants;
 
 import java.util.Collection;
 import java.util.List;
@@ -57,7 +58,13 @@ public class UiSessionContext extends SessionContext {
         userContext = Context.getUserContext();
         if (userContext != null && userContext.getAuthenticatedUser() != null) {
             User currentUser = userContext.getAuthenticatedUser();
-            Collection<Provider> providers = providerService.getProvidersByPerson(currentUser.getPerson(), false);
+            Collection<Provider> providers;
+            try {
+                Context.addProxyPrivilege(PrivilegeConstants.VIEW_PROVIDERS);
+                providers = providerService.getProvidersByPerson(currentUser.getPerson(), false);
+            } finally {
+                Context.removeProxyPrivilege(PrivilegeConstants.VIEW_PROVIDERS);
+            }
             if (providers.size() > 1) {
                 throw new IllegalStateException("Can't handle users with multiple provider accounts");
             } else if (providers.size() == 1) {


### PR DESCRIPTION
When a user in the situation described in https://issues.openmrs.org/browse/RA-737 logs in, the login succeeds and the user is then redirected to the reference application home page, but the redirect fails because the user lacks the "Get Providers" privilege. This change grants the privilege for long enough to complete this call.