### PR TITLE
RA-546 update lastSessionLocation cookie when changed from header

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appui/AppUiConstants.java
+++ b/omod/src/main/java/org/openmrs/module/appui/AppUiConstants.java
@@ -14,12 +14,12 @@
 package org.openmrs.module.appui;
 
 public class AppUiConstants {
-	
-	public static final String SESSION_ATTRIBUTE_INFO_MESSAGE = "emr.infoMessage";
-	
-	public static final String SESSION_ATTRIBUTE_TOAST_MESSAGE = "emr.toastMessage";
-	
-	public static final String SESSION_ATTRIBUTE_MANUAL_LOGOUT = "manual-logout";
 
-	public static final String COOKIE_NAME_LAST_SESSION_LOCATION = "referenceapplication.lastSessionLocation";
+    public static final String SESSION_ATTRIBUTE_INFO_MESSAGE = "emr.infoMessage";
+
+    public static final String SESSION_ATTRIBUTE_TOAST_MESSAGE = "emr.toastMessage";
+
+    public static final String SESSION_ATTRIBUTE_MANUAL_LOGOUT = "manual-logout";
+
+    public static final String COOKIE_NAME_LAST_SESSION_LOCATION = "referenceapplication.lastSessionLocation";
 }

--- a/omod/src/main/java/org/openmrs/module/appui/AppUiConstants.java
+++ b/omod/src/main/java/org/openmrs/module/appui/AppUiConstants.java
@@ -20,4 +20,6 @@ public class AppUiConstants {
 	public static final String SESSION_ATTRIBUTE_TOAST_MESSAGE = "emr.toastMessage";
 	
 	public static final String SESSION_ATTRIBUTE_MANUAL_LOGOUT = "manual-logout";
+
+	public static final String COOKIE_NAME_LAST_SESSION_LOCATION = "referenceapplication.lastSessionLocation";
 }

--- a/omod/src/main/java/org/openmrs/module/appui/fragment/controller/SessionFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/appui/fragment/controller/SessionFragmentController.java
@@ -2,6 +2,7 @@ package org.openmrs.module.appui.fragment.controller;
 
 import org.openmrs.Location;
 import org.openmrs.api.LocationService;
+import org.openmrs.module.appui.AppUiConstants;
 import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
@@ -10,11 +11,18 @@ import org.openmrs.ui.framework.fragment.action.FragmentActionResult;
 import org.openmrs.ui.framework.fragment.action.ObjectResult;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import javax.servlet.ServletContext;
+import javax.servlet.http.HttpServletResponse;
+
 public class SessionFragmentController {
 	
 	public FragmentActionResult setLocation(@RequestParam("locationId") Location location,
-	                   @SpringBean("locationService") LocationService locationService, UiSessionContext context) {
+											@SpringBean("locationService") LocationService locationService,
+											UiSessionContext context, ServletContext servletContext, HttpServletResponse httpResponse) {
 		context.setSessionLocation(location);
+		httpResponse.setHeader("Set-Cookie", AppUiConstants.COOKIE_NAME_LAST_SESSION_LOCATION + "=" + location.getLocationId()
+				+ "; HttpOnly; Path=" + servletContext.getContextPath());
+
 		return new ObjectResult(ConversionUtil.convertToRepresentation(location, Representation.DEFAULT));  // TODO: the callback in header.gsp should actually use this information instead of automatically setting the session location and id
 	}
 	

--- a/omod/src/main/java/org/openmrs/module/appui/fragment/controller/SessionFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/appui/fragment/controller/SessionFragmentController.java
@@ -1,5 +1,9 @@
 package org.openmrs.module.appui.fragment.controller;
 
+import javax.servlet.ServletContext;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletResponse;
+
 import org.openmrs.Location;
 import org.openmrs.api.LocationService;
 import org.openmrs.module.appui.AppUiConstants;
@@ -7,23 +11,30 @@ import org.openmrs.module.appui.UiSessionContext;
 import org.openmrs.module.webservices.rest.web.ConversionUtil;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.ui.framework.annotation.SpringBean;
+import org.openmrs.ui.framework.fragment.FragmentActionRequest;
 import org.openmrs.ui.framework.fragment.action.FragmentActionResult;
 import org.openmrs.ui.framework.fragment.action.ObjectResult;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import javax.servlet.ServletContext;
-import javax.servlet.http.HttpServletResponse;
-
 public class SessionFragmentController {
-	
-	public FragmentActionResult setLocation(@RequestParam("locationId") Location location,
-											@SpringBean("locationService") LocationService locationService,
-											UiSessionContext context, ServletContext servletContext, HttpServletResponse httpResponse) {
-		context.setSessionLocation(location);
-		httpResponse.setHeader("Set-Cookie", AppUiConstants.COOKIE_NAME_LAST_SESSION_LOCATION + "=" + location.getLocationId()
-				+ "; HttpOnly; Path=" + servletContext.getContextPath());
-
-		return new ObjectResult(ConversionUtil.convertToRepresentation(location, Representation.DEFAULT));  // TODO: the callback in header.gsp should actually use this information instead of automatically setting the session location and id
-	}
-	
+    
+    public FragmentActionResult setLocation(@RequestParam("locationId") Location location,
+                                            @SpringBean("locationService") LocationService locationService,
+                                            UiSessionContext context, ServletContext servletContext,
+                                            FragmentActionRequest fragmentActionRequest,
+                                            HttpServletResponse httpResponse) {
+        context.setSessionLocation(location);
+        
+        // Update lastSessionLocation cookie which was set from the context path,
+        // so next time someone logs, it will default to the same location
+        Cookie cookie = new Cookie(AppUiConstants.COOKIE_NAME_LAST_SESSION_LOCATION, location.getLocationId().toString());
+        cookie.setHttpOnly(true);
+        cookie.setPath(servletContext.getContextPath());
+        httpResponse.addCookie(cookie);
+        
+        return new ObjectResult(ConversionUtil.convertToRepresentation(location,
+                Representation.DEFAULT));
+        // TODO: the callback in header.gsp should actually use this information instead
+        // of automatically setting the session location and id
+    }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <uiframeworkVersion>3.8</uiframeworkVersion>
+        <uiframeworkVersion>3.10.1-SNAPSHOT</uiframeworkVersion>
         <appframeworkVersion>2.9</appframeworkVersion>
         <openMRSVersion>1.12.0</openMRSVersion>
         <serialization.xstreamVersion>0.2.12</serialization.xstreamVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <uiframeworkVersion>3.10.1-SNAPSHOT</uiframeworkVersion>
         <appframeworkVersion>2.9</appframeworkVersion>
-        <openMRSVersion>1.12.0</openMRSVersion>
+        <openMRSVersion>2.0.0</openMRSVersion>
         <serialization.xstreamVersion>0.2.12</serialization.xstreamVersion>
         <webservices.restVersion>2.16</webservices.restVersion>
     </properties>


### PR DESCRIPTION
I've tested these on the browser:

Now:
- changing the location from the header updates the exisiting `referenceapplication.lastSessionLocation` cookie set on the context path `/openmrs`
- same location will be used even when logouts as the same cookie is read from the homepage