### PR TITLE
RA-461 Fix to get extension which has lowest order property.

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appui/fragment/controller/HeaderFragmentController.java
+++ b/omod/src/main/java/org/openmrs/module/appui/fragment/controller/HeaderFragmentController.java
@@ -43,7 +43,8 @@ public class HeaderFragmentController {
             fragmentModel.addAttribute("loginLocations", appFrameworkService.getLoginLocations());
 
             List<Extension> exts = appFrameworkService.getExtensionsForCurrentUser(AppUiExtensions.HEADER_CONFIG_EXTENSION);
-            Map<String, Object> configSettings = exts.size() > 0 ? exts.get(0).getExtensionParams() : null;
+            Extension lowestOrderExtension = getLowestOrderExtenstion(exts);
+            Map<String, Object> configSettings = lowestOrderExtension.getExtensionParams();
             fragmentModel.addAttribute("configSettings", configSettings);
             List<Extension> userAccountMenuItems = appFrameworkService.getExtensionsForCurrentUser(AppUiExtensions.HEADER_USER_ACCOUNT_MENU_ITEMS_EXTENSION);
             fragmentModel.addAttribute("userAccountMenuItems", userAccountMenuItems);
@@ -51,6 +52,16 @@ public class HeaderFragmentController {
             Context.removeProxyPrivilege(GET_LOCATIONS);
             Context.removeProxyPrivilege(VIEW_LOCATIONS);
         }
+    }
+
+    public Extension getLowestOrderExtenstion(List<Extension> exts) {
+        Extension lowestOrderExtension = exts.size() > 0 ? exts.get(0) : null;
+        for(Extension ext : exts) {
+            if (lowestOrderExtension.getOrder() > ext.getOrder()) {
+                lowestOrderExtension = ext;
+            }
+        }
+        return lowestOrderExtension;
     }
 
     public void logout(HttpServletRequest request) throws IOException {

--- a/omod/src/test/java/org/openmrs/module/appui/fragment/controller/HeaderFragmentControllerTest.java
+++ b/omod/src/test/java/org/openmrs/module/appui/fragment/controller/HeaderFragmentControllerTest.java
@@ -1,0 +1,27 @@
+package org.openmrs.module.appui.fragment.controller;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.openmrs.module.appframework.domain.Extension;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class HeaderFragmentControllerTest {
+
+    Extension ext1 = new Extension("1","app1","extp1","type","ext1","url",1);
+    Extension ext2 = new Extension("2","app2","extp2","type","ext2","url",2);
+    Extension ext3 = new Extension("3","app3","extp3","type","ext3","url",3);
+
+    @Test
+    public void shouldReturnLowsetExtension() {
+        List<Extension> exts = new ArrayList<Extension>();
+        exts.add(ext1);
+        exts.add(ext2);
+        exts.add(ext3);
+
+        HeaderFragmentController headerFragmentController=new HeaderFragmentController();
+        Assert.assertEquals(headerFragmentController.getLowestOrderExtenstion(exts),ext1);
+
+    }
+}


### PR DESCRIPTION
## Ticket ## 

Ticket Info - https://issues.openmrs.org/browse/RA-461

## Summary ##
We need to allow a module to override the icon and URL even if the reference application module is doing so already. So the quick fix will be instead of getting the first extension, It should get the one with the lowest order property.

## Work Done ## 

Fix to get the extension which has the lowest order property. 