### PR TITLE
RA-1503 Added implementation to store the session location in userContext

### DIFF
--- a/omod/src/main/java/org/openmrs/module/appui/UiSessionContext.java
+++ b/omod/src/main/java/org/openmrs/module/appui/UiSessionContext.java
@@ -82,6 +82,9 @@ public class UiSessionContext extends SessionContext {
         }
         this.sessionLocation = sessionLocation;
         this.sessionLocationId = sessionLocation.getId();
+        if (userContext != null && userContext.getAuthenticatedUser() != null) {
+            userContext.setLocationId(this.sessionLocationId);
+        }
     }
 
     @Override


### PR DESCRIPTION
# Description # 

Logged-in user session information can be fetched only from the web layer. If we want to get the currently logged-in user location information, then we need to call a given REST API .

This implementation will keep the logged-in user session location information into the UserContext to extend the API level usage.

# Ticket Information # 

Ticket : https://issues.openmrs.org/browse/RA-1503