### PR TITLE
Revert "RA-1706, Menu position in small viewport"

### DIFF
--- a/omod/src/main/webapp/fragments/header.gsp
+++ b/omod/src/main/webapp/fragments/header.gsp
@@ -114,16 +114,15 @@
 
 </script>
 <header>
-
+    <div class="logo">
+        <a href="${ logoLinkUrl }">
+            <img src="${ logoIconUrl }"/>
+        </a>
+    </div>
     <% if (context.authenticated) { %>
 
         <% if (useBootstrap) { %>
             <nav class="navbar navbar-expand-lg navbar-dark navigation">
-                <div class="logo">
-                    <a href="${ logoLinkUrl }">
-                        <img src="${ logoIconUrl }"/>
-                    </a>
-                </div>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
                 </button>
@@ -132,11 +131,6 @@
                     <ul class="navbar-nav ml-auto user-options">
                     <li class="nav-item identifier">
         <% } else { %>
-                    <div class="logo">
-                        <a href="${ logoLinkUrl }">
-                            <img src="${ logoIconUrl }"/>
-                        </a>
-                    </div>
                     <ul class="user-options">
                     <li class="identifier">
         <% } %>


### PR DESCRIPTION
Reverts openmrs/openmrs-module-appui#32

this commit removes the header entirely if the user is not authenticated (ie on the login page)... note  how the logo used to live outside the context.authenticated block. 
see more  comments here https://issues.openmrs.org/browse/RA-1706